### PR TITLE
Fix daemonset and add prometheusrule + servicemonitor

### DIFF
--- a/helm/dmesg/templates/daemonset.yaml
+++ b/helm/dmesg/templates/daemonset.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "dmesg.name" . }}
@@ -40,14 +39,17 @@ spec:
             httpGet:
               path: /
               port: http
-          volumes:
+          volumeMounts:
             - name: kmsg-device
-              hostPath:
-                path: /dev/kmsg
+              mountPath: /dev/kmsg
           securityContext:
             privileged: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: kmsg-device
+          hostPath:
+            path: /dev/kmsg
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/dmesg/templates/prometheusrule.yaml
+++ b/helm/dmesg/templates/prometheusrule.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "dmesg.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: {{ include "dmesg.name" . }}
+    helm.sh/chart: {{ include "dmesg.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  groups:
+  {{- with .Values.prometheusRule.rules }}
+    - name: {{ template "dmesg.name" $ }}
+      rules:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/helm/dmesg/templates/servicemonitor.yaml
+++ b/helm/dmesg/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dmesg.fullname" . }}-monitor
+  annotations:
+    app.kubernetes.io/name: {{ include "dmesg.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  endpoints:
+  - port: http
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "dmesg.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/dmesg/templates/servicemonitor.yaml
+++ b/helm/dmesg/templates/servicemonitor.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ include "dmesg.fullname" . }}-monitor
   annotations:
     app.kubernetes.io/name: {{ include "dmesg.name" . }}
+    helm.sh/chart: {{ include "dmesg.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   endpoints:
   - port: http

--- a/helm/dmesg/values.yaml
+++ b/helm/dmesg/values.yaml
@@ -37,3 +37,33 @@ service:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "80"
+
+serviceMonitor:
+  enabled: true
+prometheusRule:
+  enabled: true
+  rules:
+  - alert: DMESGInfo
+    expr: increase(dmesg_logs{priority="info"}[5m]) > 50
+    for: 1m
+    labels:
+      severity: info
+    annotations:
+      summary: dmesg info on "{{ $labels.instance }}"
+      description: Kernel info reached more than 50
+  - alert: DMESGWarnings
+    expr: increase(dmesg_logs{priority="warning"}[5m]) > 20
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: dmesg warnings on "{{ $labels.instance }}"
+      description: Kernel warnings reached more than 20
+  - alert: DMESGErrors
+    expr: increase(dmesg_logs{priority="err"}[5m]) > 1
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: dmesg errors on "{{ $labels.instance }}"
+      description: Kernel errors


### PR DESCRIPTION
Tried to deploy this to our Kubernetes Cluster and fixed the daemonset.

This will work with Rancher Monitoring out of the box and create alerts for errors, warnings and info